### PR TITLE
Allow compile for Windows

### DIFF
--- a/.github/workflows/build-publish.yml
+++ b/.github/workflows/build-publish.yml
@@ -73,10 +73,41 @@ jobs:
       with:
         path: dist/*.tar.gz
 
+  build-wheels-ms:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        python-version: [ '3.7', '3.8', '3.9', '3.10' ]
+        include:
+        - os: windows-latest
+
+    steps:
+    - uses: actions/checkout@v3
+    
+    - name: Set up Python
+      uses: actions/setup-python@v3
+      with:
+        python-version: ${{ matrix.python-version }}
+        architecture: x64
+
+    - name: Add MSBuild to PATH
+      uses: microsoft/setup-msbuild@v1.0.2
+
+    - name: Build wheel
+      working-directory: ${{env.GITHUB_WORKSPACE}}
+      run:  |
+        pip install wheel cmake-build-extension
+        pip wheel .  --no-deps -w wheelhouse/ 
+        
+    - uses: actions/upload-artifact@v3
+      with:
+        path: ./wheelhouse/*.whl        
+        
   publish:
     runs-on: ubuntu-latest
     needs:
     - build-wheels
+    - build-wheels-ms
     - build-src
     if: github.event_name == 'release' && github.event.action == 'published'
     steps:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,7 +16,11 @@ set(LIB_SRC_FILES ${autopilot_sources})
 
 
 set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -g -Wall -std=c++11 -O3")
-set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-unused-variable -Wno-reorder -Wno-sign-compare -Wno-missing-braces")
+IF (WIN32)
+  set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
+ELSE()
+  set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-unused-variable -Wno-reorder -Wno-sign-compare -Wno-missing-braces")
+ENDIF()
 set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DDEBUG")
 
 # runtime library

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,7 +17,7 @@ set(LIB_SRC_FILES ${autopilot_sources})
 
 set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -g -Wall -std=c++11 -O3")
 IF (WIN32)
-  set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
+  set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /W0 /wd4711 /wd4710")
 ELSE()
   set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-unused-variable -Wno-reorder -Wno-sign-compare -Wno-missing-braces")
 ENDIF()

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,6 @@
 include CMakeLists.txt
 recursive-include src *
 include *.dylib
+include *.dll
 include *.so
 include *.gif

--- a/magent/c_lib.py
+++ b/magent/c_lib.py
@@ -16,6 +16,8 @@ def _load_lib():
         path_to_so_file = os.path.join(lib_path, "libmagent.dylib")
     elif platform.system() == 'Linux':
         path_to_so_file = os.path.join(lib_path, "libmagent.so")
+    elif platform.system() == 'Windows':
+        path_to_so_file = os.path.join(lib_path, "magent.dll")
     else:
         raise BaseException("unsupported system: " + platform.system())
     lib = ctypes.CDLL(path_to_so_file, ctypes.RTLD_GLOBAL)

--- a/setup.py
+++ b/setup.py
@@ -54,24 +54,40 @@ class CMakeBuild(build_ext):
                 ["cmake", ext.sourcedir] + cmake_config_args, cwd=make_location
             )
             print(ext.name)
-            subprocess.check_call(["pwd"])
-            print(extdir)
-            subprocess.check_call(["ls"])
+            if platform.system() == "Windows":
+              cdir = str(subprocess.check_output(["cd"], shell=True).decode()).strip()
+              #subprocess.check_call(["dir"], shell=True)
+            else:
+              subprocess.check_call(["pwd"])
+              print(extdir)
+              subprocess.check_call(["ls"])
+
             lib_ext = ""
+            lib_name = ""
 
             if platform.system() == "Darwin":
                 lib_ext = ".dylib"
+                lib_name = "libmagent"
                 thread_num = check_output(["sysctl", "-n", "hw.ncpu"], encoding="utf-8")
                 subprocess.check_call(
                     ["make", "-C", make_location, "-j", str(thread_num).rstrip()], cwd=extdir
                 )
             elif platform.system() == "Linux":
                 lib_ext = ".so"
+                lib_name = "libmagent"
                 thread_num = check_output(["nproc"], encoding="utf-8")
                 subprocess.check_call(
                     ["make", "-C", make_location, "-j", str(thread_num).rstrip()], cwd=extdir
                 )
-
+            elif platform.system() == "Windows":
+                lib_ext = ".dll"
+                lib_name = "magent"
+                thread_num = 1
+                # cmake --build . --target ALL_BUILD --config Release
+                subprocess.check_call(
+                    ["cmake",
+                    "--build",".","--target","ALL_BUILD","--config",cfg], cwd=make_location
+                , shell=True)
             # build_res_dir = extdir + "/magent/build/"
             # if not os.path.exists(build_res_dir):
             #     os.makedirs(build_res_dir)

--- a/src/gridworld/GridWorld.cc
+++ b/src/gridworld/GridWorld.cc
@@ -251,7 +251,11 @@ void GridWorld::add_agents(GroupHandle group, int n, const char *method,
                 }
 
                 agent->set_dir(turn_mode ? (Direction) pos_dir[i] : NORTH);
+#if defined(_WIN32)                
+                agent->set_pos({pos_x[i], pos_y[i]});
+#else                
                 agent->set_pos((Position) {pos_x[i], pos_y[i]});
+#endif              
 
                 ret = map.add_agent(agent, base_channel_id);
                 add_or_error(ret, pos_x[i], pos_y[i], id_counter, g, agent);

--- a/src/gridworld/GridWorld.cc
+++ b/src/gridworld/GridWorld.cc
@@ -251,11 +251,7 @@ void GridWorld::add_agents(GroupHandle group, int n, const char *method,
                 }
 
                 agent->set_dir(turn_mode ? (Direction) pos_dir[i] : NORTH);
-#if defined(_WIN32)                
                 agent->set_pos({pos_x[i], pos_y[i]});
-#else                
-                agent->set_pos((Position) {pos_x[i], pos_y[i]});
-#endif              
 
                 ret = map.add_agent(agent, base_channel_id);
                 add_or_error(ret, pos_x[i], pos_y[i], id_counter, g, agent);

--- a/src/gridworld/GridWorld.cc
+++ b/src/gridworld/GridWorld.cc
@@ -467,7 +467,7 @@ void GridWorld::step(int *done) {
 
     // shuffle attacks
     for (int i = 0; i < attack_size; i++) {
-        int j = (int)random_engine() % (i+1);
+        int j = (int)random_engine() % (unsigned long)(i+1);
         std::swap(attack_buffer[i], attack_buffer[j]);
     }
 

--- a/src/gridworld/Map.cc
+++ b/src/gridworld/Map.cc
@@ -49,8 +49,8 @@ void Map::reset(int width, int height, bool food_mode) {
 Position Map::get_random_blank(std::default_random_engine &random_engine, int width, int height) {
     int tries = 0;
     while (true) {
-        int x = (int) random_engine() % (w - width);
-        int y = (int) random_engine() % (h - height);
+        int x = (int) random_engine() % (unsigned long)(w - width);
+        int y = (int) random_engine() % (unsigned long)(h - height);
 
         if (is_blank_area(x, y, width, height)) {
             return Position{x, y};

--- a/src/runtime_api.cc
+++ b/src/runtime_api.cc
@@ -11,7 +11,7 @@
 /**
  *  General Environment
  */
-int env_new_game(EnvHandle *game, const char *name) {
+DLL_EXPORT int env_new_game(EnvHandle *game, const char *name) {
     using ::magent::utility::strequ;
 
     if (strequ(name, "GridWorld")) {
@@ -22,64 +22,64 @@ int env_new_game(EnvHandle *game, const char *name) {
     return 0;
 }
 
-int env_delete_game(EnvHandle game) {
+DLL_EXPORT int env_delete_game(EnvHandle game) {
     LOG(TRACE) << "env delete game.  ";
     delete game;
     return 0;
 }
 
-int env_config_game(EnvHandle game, const char *name, void *p_value) {
+DLL_EXPORT int env_config_game(EnvHandle game, const char *name, void *p_value) {
     LOG(TRACE) << "env config game.  ";
     game->set_config(name, p_value);
     return 0;
 }
 
 // run step
-int env_reset(EnvHandle game) {
+DLL_EXPORT int env_reset(EnvHandle game) {
     LOG(TRACE) << "env reset.  ";
     game->reset();
     return 0;
 }
 
-int env_get_observation(EnvHandle game, GroupHandle group, float **buffer) {
+DLL_EXPORT int env_get_observation(EnvHandle game, GroupHandle group, float **buffer) {
     LOG(TRACE) << "env get observation.  ";
     game->get_observation(group, buffer);
     return 0;
 }
 
-int env_set_action(EnvHandle game, GroupHandle group, const int *actions) {
+DLL_EXPORT int env_set_action(EnvHandle game, GroupHandle group, const int *actions) {
     LOG(TRACE) << "env set action.  ";
     game->set_action(group, actions);
     return 0;
 }
 
-int env_step(EnvHandle game, int *done) {
+DLL_EXPORT int env_step(EnvHandle game, int *done) {
     LOG(TRACE) << "env step.  ";
     game->step(done);
     return 0;
 }
 
-int env_get_reward(EnvHandle game, GroupHandle group, float *buffer) {
+DLL_EXPORT int env_get_reward(EnvHandle game, GroupHandle group, float *buffer) {
     LOG(TRACE) << "env get reward.  ";
     game->get_reward(group, buffer);
     return 0;
 }
 
 // info getter
-int env_get_info(EnvHandle game, GroupHandle group, const char *name, void *buffer) {
+DLL_EXPORT int env_get_info(EnvHandle game, GroupHandle group, const char *name, void *buffer) {
     LOG(TRACE) << "env get info " << name << ".  ";
     game->get_info(group, name, buffer);
     return 0;
 }
 
 // render
-int env_render(EnvHandle game) {
+DLL_EXPORT int env_render(EnvHandle game) {
     LOG(TRACE) << "env render.  ";
     game->render();
     return 0;
 }
 
-int env_render_next_file(EnvHandle game) {
+DLL_EXPORT int env_render_next_file(EnvHandle game) {
     LOG(TRACE) << "env render next file.  ";
     // temporally only needed in DiscreteSnake
     //((::magent::discrete_snake::DiscreteSnake *)game)->render_next_file();
@@ -90,20 +90,20 @@ int env_render_next_file(EnvHandle game) {
  *  GridWorld special
  */
 // agent
-int gridworld_register_agent_type(EnvHandle game, const char *name, int n,
+DLL_EXPORT int gridworld_register_agent_type(EnvHandle game, const char *name, int n,
                                   const char **keys, float *values) {
     LOG(TRACE) << "gridworld register agent type.  ";
     ((::magent::gridworld::GridWorld *)game)->register_agent_type(name, n, keys, values);
     return 0;
 }
 
-int gridworld_new_group(EnvHandle game, const char *agent_type_Name, GroupHandle *group) {
+DLL_EXPORT int gridworld_new_group(EnvHandle game, const char *agent_type_Name, GroupHandle *group) {
     LOG(TRACE) << "gridworld new group.  ";
     ((::magent::gridworld::GridWorld *)game)->new_group(agent_type_Name, group);
     return 0;
 }
 
-int gridworld_add_agents(EnvHandle game, GroupHandle group, int n, const char *method,
+DLL_EXPORT int gridworld_add_agents(EnvHandle game, GroupHandle group, int n, const char *method,
                          const int *pos_x, const int *pos_y, const int *dir) {
     LOG(TRACE) << "gridworld add agents.  ";
     ((::magent::gridworld::GridWorld *)game)->add_agents(group, n, method, pos_x, pos_y, dir);
@@ -111,32 +111,32 @@ int gridworld_add_agents(EnvHandle game, GroupHandle group, int n, const char *m
 }
 
 // run step
-int gridworld_clear_dead(EnvHandle game) {
+DLL_EXPORT int gridworld_clear_dead(EnvHandle game) {
     LOG(TRACE) << "gridworld clear dead.  ";
     ((::magent::gridworld::GridWorld *)game)->clear_dead();
     return 0;
 }
 
-int gridworld_set_goal(EnvHandle game, GroupHandle group, const char *method, const int *linear_buffer) {
+DLL_EXPORT int gridworld_set_goal(EnvHandle game, GroupHandle group, const char *method, const int *linear_buffer) {
     LOG(TRACE) << "gridworld clear dead.  ";
     ((::magent::gridworld::GridWorld *)game)->set_goal(group, method, linear_buffer);
     return 0;
 }
 
 // reward description
-int gridworld_define_agent_symbol(EnvHandle game, int no, int group, int index) {
+DLL_EXPORT int gridworld_define_agent_symbol(EnvHandle game, int no, int group, int index) {
     LOG(TRACE) << "gridworld define agent symbol";
     ((::magent::gridworld::GridWorld *)game)->define_agent_symbol(no, group, index);
     return 0;
 }
 
-int gridworld_define_event_node(EnvHandle game, int no, int op, int *inputs, int n_inputs) {
+DLL_EXPORT int gridworld_define_event_node(EnvHandle game, int no, int op, int *inputs, int n_inputs) {
     LOG(TRACE) << "gridworld define event node";
     ((::magent::gridworld::GridWorld *)game)->define_event_node(no, op, inputs, n_inputs);
     return 0;
 }
 
-int gridworld_add_reward_rule(EnvHandle game, int on, int *receiver, float *value, int n_receiver,
+DLL_EXPORT int gridworld_add_reward_rule(EnvHandle game, int on, int *receiver, float *value, int n_receiver,
                               bool is_terminal, bool auto_value) {
     LOG(TRACE) << "gridworld add reward rule";
     ((::magent::gridworld::GridWorld *)game)->add_reward_rule(on, receiver, value, n_receiver, is_terminal, auto_value);

--- a/src/runtime_api.h
+++ b/src/runtime_api.h
@@ -8,6 +8,12 @@
 
 #include "Environment.h"
 
+#ifdef _MSC_VER
+#define DLL_EXPORT  __declspec( dllexport )
+#else
+#define DLL_EXPORT
+#endif
+
 extern "C" {
 
 using ::magent::environment::EnvHandle;
@@ -17,41 +23,41 @@ using ::magent::environment::GroupHandle;
  *  General Environment
  */
 // game
-int env_new_game(EnvHandle *game, const char *name);
-int env_delete_game(EnvHandle game);
-int env_config_game(EnvHandle game, const char *name, void *p_value);
+DLL_EXPORT int env_new_game(EnvHandle *game, const char *name);
+DLL_EXPORT int env_delete_game(EnvHandle game);
+DLL_EXPORT int env_config_game(EnvHandle game, const char *name, void *p_value);
 
 // run step
-int env_reset(EnvHandle game);
-int env_get_observation(EnvHandle game, GroupHandle group, float **buffer);
-int env_set_action(EnvHandle game, GroupHandle group, const int *actions);
-int env_step(EnvHandle game, int *done);
-int env_get_reward(EnvHandle game, GroupHandle group, float *buffer);
+DLL_EXPORT int env_reset(EnvHandle game);
+DLL_EXPORT int env_get_observation(EnvHandle game, GroupHandle group, float **buffer);
+DLL_EXPORT int env_set_action(EnvHandle game, GroupHandle group, const int *actions);
+DLL_EXPORT int env_step(EnvHandle game, int *done);
+DLL_EXPORT int env_get_reward(EnvHandle game, GroupHandle group, float *buffer);
 
 // info getter
-int env_get_info(EnvHandle game, GroupHandle group, const char *name, void *buffer);
+DLL_EXPORT int env_get_info(EnvHandle game, GroupHandle group, const char *name, void *buffer);
 
 // render
-int env_render(EnvHandle game);
-int env_render_next_file(EnvHandle game);
+DLL_EXPORT int env_render(EnvHandle game);
+DLL_EXPORT int env_render_next_file(EnvHandle game);
 
 /**
  *  GridWorld special
  */
 // agent
-int gridworld_register_agent_type(EnvHandle game, const char *name, int n, const char **keys, float *values);
-int gridworld_new_group(EnvHandle game, const char *agent_type_name, GroupHandle *group);
-int gridworld_add_agents(EnvHandle game, GroupHandle group, int n, const char *method,
+DLL_EXPORT int gridworld_register_agent_type(EnvHandle game, const char *name, int n, const char **keys, float *values);
+DLL_EXPORT int gridworld_new_group(EnvHandle game, const char *agent_type_name, GroupHandle *group);
+DLL_EXPORT int gridworld_add_agents(EnvHandle game, GroupHandle group, int n, const char *method,
                          const int *pos_x, const int *pos_y, const int *dir);
 
 // run step
-int gridworld_clear_dead(EnvHandle game);
-int gridworld_set_goal(EnvHandle game, GroupHandle group, const char *method, const int *linear_buffer);
+DLL_EXPORT int gridworld_clear_dead(EnvHandle game);
+DLL_EXPORT int gridworld_set_goal(EnvHandle game, GroupHandle group, const char *method, const int *linear_buffer);
 
 // reward description
-int gridworld_define_agent_symbol(EnvHandle game, int no, int group, int index);
-int gridworld_define_event_node(EnvHandle game, int no, int op, int *inputs, int n_inputs);
-int gridworld_add_reward_rule(EnvHandle game, int on, int *receiver, float *value, int n_receiver,
+DLL_EXPORT int gridworld_define_agent_symbol(EnvHandle game, int no, int group, int index);
+DLL_EXPORT int gridworld_define_event_node(EnvHandle game, int no, int op, int *inputs, int n_inputs);
+DLL_EXPORT int gridworld_add_reward_rule(EnvHandle game, int on, int *receiver, float *value, int n_receiver,
                               bool is_terminal, bool auto_value);
 
 
@@ -59,12 +65,12 @@ int gridworld_add_reward_rule(EnvHandle game, int on, int *receiver, float *valu
 /**
  * Temporary C Booster
  */
-void runaway_infer_action(float *obs_buf, float *feature_buf, int n, int height, int width, int n_channel,
+DLL_EXPORT void runaway_infer_action(float *obs_buf, float *feature_buf, int n, int height, int width, int n_channel,
                           int attack_base, int *act_buf, int away_channel, int move_back);
-void rush_prey_infer_action(float *obs_buf, float *feature_buf, int n, int height,  int width, int n_channel,
+DLL_EXPORT void rush_prey_infer_action(float *obs_buf, float *feature_buf, int n, int height,  int width, int n_channel,
                             int *act_buf, int attack_channel, int attack_base,
                             int *view2attack_buf, float threshold);
-void gather_infer_action(float *obs_buf, float *hp_buf, int n, int height, int width, int n_channel,
+DLL_EXPORT void gather_infer_action(float *obs_buf, float *hp_buf, int n, int height, int width, int n_channel,
                          int *act_buf, int attack_base, int *view2attack_buf);
 }
 

--- a/src/temp_c_booster.cc
+++ b/src/temp_c_booster.cc
@@ -8,10 +8,19 @@
 #include <cmath>
 #include <vector>
 #include "utility/utility.h"
+#if defined(_WIN32)
+#define random rand
+#endif 
+
+#ifdef _MSC_VER
+#define DLL_EXPORT  __declspec( dllexport )
+#else
+#define DLL_EXPORT
+#endif
 
 using magent::utility::NDPointer;
 
-void runaway_infer_action(float *obs_buf, float *feature_buf, int n, int height, int width, int n_channel,
+DLL_EXPORT void runaway_infer_action(float *obs_buf, float *feature_buf, int n, int height, int width, int n_channel,
                           int attack_base, int *act_buf, int away_channel, int move_back) {
     int wall  = 0;
     int food  = 1;
@@ -36,7 +45,7 @@ void runaway_infer_action(float *obs_buf, float *feature_buf, int n, int height,
     }
 }
 
-void rush_prey_infer_action(float *obs_buf, float *feature_buf, int n, int height, int width, int n_channel,
+DLL_EXPORT  void rush_prey_infer_action(float *obs_buf, float *feature_buf, int n, int height, int width, int n_channel,
                             int *act_buf, int attack_channel, int attack_base,
                             int *view2attack_buf, float threshold) {
     NDPointer<int, 2> view2attack(view2attack_buf, {{height, width}});
@@ -82,7 +91,7 @@ void rush_prey_infer_action(float *obs_buf, float *feature_buf, int n, int heigh
     }
 }
 
-int get_action(const std::pair<int, int> &disp, bool stride) {
+DLL_EXPORT  int get_action(const std::pair<int, int> &disp, bool stride) {
     int action = -1;
     if (disp.first < 0) {
         if (disp.second < 0) {
@@ -112,7 +121,7 @@ int get_action(const std::pair<int, int> &disp, bool stride) {
     return action;
 }
 
-void gather_infer_action(float *obs_buf, float *hp_buf, int n, int height, int width, int n_channel,
+DLL_EXPORT  void gather_infer_action(float *obs_buf, float *hp_buf, int n, int height, int width, int n_channel,
                          int *act_buf, int attack_base, int *view2attack_buf) {
     NDPointer<int, 2> view2attack(view2attack_buf, {{height, width}});
 


### PR DESCRIPTION
# Description
If you are interested in a wheel for Windows, have a look at the pull request code. It is quickly hacked (e.g. there is one type cast error which for Windows I just removed) and not well tested but it does create the windows wheel which works with the pettingzoo magent examples. More testing then a quick run whether the agents move and the pygame Gui is displayed was not done. But maybe it serves as a starting point for you.

To build the wheel I did:

**1. Do once**
python -m venv magent_venv
magent_venv\scripts\activate
pip install cmake-build-extension wheel

**2. BUILD Wheel**
python setup.py bdist_wheel
gives
=> dist\magent-0.2.0-cp38-cp38-win_amd64.whl